### PR TITLE
Update actions versions and runner commands

### DIFF
--- a/.github/workflows/upstream-pr.yml
+++ b/.github/workflows/upstream-pr.yml
@@ -17,13 +17,13 @@ jobs:
           - retrace-server
     steps:
       - name: Check out ${{ matrix.component }} translations
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: translations
           ref: ${{ matrix.component }}
 
       - name: Check out upstream ${{ matrix.component }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: upstream
           repository: abrt/${{ matrix.component }}
@@ -40,11 +40,11 @@ jobs:
             exit 0
 
           echo 'Translation files updated'
-          echo '::set-output name=create-pr::1'
+          echo 'create-pr=1' >> $GITHUB_OUTPUT
 
       - name: Create pull request in upstream repository
         if: ${{ steps.update-translations.outputs.create-pr }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           branch: translations-update
           path: upstream/

--- a/.github/workflows/upstream-pr.yml
+++ b/.github/workflows/upstream-pr.yml
@@ -17,13 +17,13 @@ jobs:
           - retrace-server
     steps:
       - name: Check out ${{ matrix.component }} translations
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: translations
           ref: ${{ matrix.component }}
 
       - name: Check out upstream ${{ matrix.component }} repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: upstream
           repository: abrt/${{ matrix.component }}


### PR DESCRIPTION
[GitHub deprecated Node 12 for Actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and `actions/checkout@v3` and `peter-evans/create-pull-request@v5` (since v4, actually) reflect this change.

[set-output is deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and could be removed at any time, so updating to the new recommended replacement.