### PR TITLE
Disable the archived retrace-server

### DIFF
--- a/.github/workflows/upstream-pr.yml
+++ b/.github/workflows/upstream-pr.yml
@@ -9,12 +9,12 @@ jobs:
   pr:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         component:
           - abrt
           - gnome-abrt
           - libreport
-          - retrace-server
     steps:
       - name: Check out ${{ matrix.component }} translations
         uses: actions/checkout@v4


### PR DESCRIPTION
And add `fail-fast: false` to not cancel other matrix jobs if one fails.

fixes #5